### PR TITLE
Fix Elasticsearch index creation check

### DIFF
--- a/src/elasticsearch.ts
+++ b/src/elasticsearch.ts
@@ -8,7 +8,7 @@ export const es = new Client({
 
 export async function ensureIndex() {
     const index = 'emails';
-    const exists = await es.indices.exists({ index });
+    const { body: exists } = await es.indices.exists({ index });
     if (!exists) {
         await es.indices.create({
             index,


### PR DESCRIPTION
## Summary
- fix a logic bug in `ensureIndex` so the `emails` index gets created

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b05df544083279c378c5807776125