### PR TITLE
Improve email preview and multi-account UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from "react";
 import EmailCard from "./components/EmailCard";
 import ConnectAccountButton from "./components/ConnectAccountButton";
 import SearchBar from "./components/SearchBar";
+import AccountSelector from "./components/AccountSelector";
+import CategoryFilter from "./components/CategoryFilter";
 
 type Email = {
     subject: string;
@@ -12,32 +14,60 @@ type Email = {
 function App() {
     const [emails, setEmails] = useState<Email[]>([]);
     const [search, setSearch] = useState("");
+    const [accounts, setAccounts] = useState<string[]>([]);
     const [account, setAccount] = useState<string | null>(null);
+    const [category, setCategory] = useState<string>("");
 
+    // Load accounts from localStorage and handle OAuth redirect
     useEffect(() => {
         const params = new URLSearchParams(window.location.search);
         const acc = params.get("account");
-        if (acc) setAccount(acc);
+
+        const stored = JSON.parse(localStorage.getItem("accounts") || "[]") as string[];
+
+        if (acc) {
+            if (!stored.includes(acc)) {
+                stored.push(acc);
+                localStorage.setItem("accounts", JSON.stringify(stored));
+            }
+            setAccount(acc);
+        } else if (stored.length > 0) {
+            setAccount(stored.length > 1 ? "" : stored[0]);
+        }
+
+        setAccounts(stored);
     }, []);
 
     useEffect(() => {
-        if (!account) return;
-        fetch(`/search?account=${account}&q=${search}`)
+        if (account === null) return;
+
+        const params = new URLSearchParams();
+        if (account) params.append("account", account);
+        if (search) params.append("q", search);
+        if (category) params.append("category", category);
+
+        const url = `/search?${params.toString()}`;
+        fetch(url)
             .then(res => res.json())
             .then(data => setEmails(data))
             .catch(console.error);
-    }, [search, account]);
+    }, [search, account, category]);
 
     return (
-        <div className="p-6 max-w-3xl mx-auto">
+        <div className="p-6 max-w-5xl mx-auto">
             <h1 className="text-2xl font-bold mb-4">📬 Your Onebox Emails</h1>
 
-            {!account ? (
+            {account === null && accounts.length === 0 ? (
                 <ConnectAccountButton />
             ) : (
                 <>
-                    <p className="mb-2">Logged in as <b>{account}</b></p>
+                    <AccountSelector
+                        accounts={accounts}
+                        selected={account}
+                        onSelect={(acc) => setAccount(acc)}
+                    />
                     <SearchBar onSearch={setSearch} />
+                    <CategoryFilter selected={category} onSelect={setCategory} />
                     <div className="mt-4 space-y-2">
                         {emails.length === 0 ? (
                             <p>No emails found.</p>

--- a/frontend/src/components/AccountSelector.tsx
+++ b/frontend/src/components/AccountSelector.tsx
@@ -1,0 +1,32 @@
+import ConnectAccountButton from "./ConnectAccountButton";
+
+export default function AccountSelector({
+    accounts,
+    selected,
+    onSelect,
+}: {
+    accounts: string[];
+    selected: string | null;
+    onSelect: (acc: string) => void;
+}) {
+    return (
+        <div className="flex items-center space-x-2 mb-4">
+            <select
+                className="border px-2 py-1 rounded"
+                value={selected ?? ''}
+                onChange={(e) => onSelect(e.target.value)}
+            >
+                {accounts.length === 0 && <option value="">No accounts</option>}
+                {accounts.length > 1 && (
+                    <option value="">All accounts</option>
+                )}
+                {accounts.map((acc) => (
+                    <option key={acc} value={acc}>
+                        {acc}
+                    </option>
+                ))}
+            </select>
+            <ConnectAccountButton />
+        </div>
+    );
+}

--- a/frontend/src/components/CategoryFilter.tsx
+++ b/frontend/src/components/CategoryFilter.tsx
@@ -1,0 +1,29 @@
+import { CATEGORIES } from '../constants';
+
+export default function CategoryFilter({
+    selected,
+    onSelect,
+}: {
+    selected: string;
+    onSelect: (c: string) => void;
+}) {
+    return (
+        <div className="flex flex-wrap gap-2 mb-4">
+            <button
+                className={`px-2 py-1 rounded ${selected === '' ? 'bg-blue-600 text-white' : 'bg-gray-200'}`}
+                onClick={() => onSelect('')}
+            >
+                All
+            </button>
+            {CATEGORIES.map((cat) => (
+                <button
+                    key={cat}
+                    className={`px-2 py-1 rounded ${selected === cat ? 'bg-blue-600 text-white' : 'bg-gray-200'}`}
+                    onClick={() => onSelect(cat)}
+                >
+                    {cat}
+                </button>
+            ))}
+        </div>
+    );
+}

--- a/frontend/src/components/EmailCard.tsx
+++ b/frontend/src/components/EmailCard.tsx
@@ -4,14 +4,30 @@ type Email = {
     label: string;
 };
 
+import { useState } from 'react';
+
 export default function EmailCard({ email }: { email: Email }) {
+    const [open, setOpen] = useState(false);
+    const snippet =
+        email.body.length > 120 ? email.body.slice(0, 120) + '...' : email.body;
+
     return (
         <div className="border p-4 rounded shadow-sm">
-            <h3 className="font-bold">{email.subject}</h3>
-            <p className="text-gray-700 mt-1 whitespace-pre-line">{email.body}</p>
-            <span className="mt-2 inline-block bg-gray-200 text-sm px-2 py-1 rounded">
-        {email.label}
-      </span>
+            <h3 className="font-bold mb-1">{email.subject}</h3>
+            <p className="text-gray-700 whitespace-pre-line">
+                {open ? email.body : snippet}
+            </p>
+            <div className="mt-2 flex items-center space-x-2">
+                <span className="inline-block bg-gray-200 text-sm px-2 py-1 rounded">
+                    {email.label}
+                </span>
+                <button
+                    className="text-blue-600 text-sm underline"
+                    onClick={() => setOpen(!open)}
+                >
+                    {open ? 'Hide' : 'Open'}
+                </button>
+            </div>
         </div>
     );
 }

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,0 +1,8 @@
+export const CATEGORIES = [
+    'Interested',
+    'Meeting Booked',
+    'Not Interested',
+    'Spam',
+    'Out of Office',
+    'Uncategorized',
+];

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,114 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #fafafa;
+}
+
+button {
+    cursor: pointer;
+}
+
+.flex {
+    display: flex;
+}
+
+.space-x-2 > * + * {
+    margin-left: 0.5rem;
+}
+
+.flex-wrap {
+    flex-wrap: wrap;
+}
+
+.gap-2 > * {
+    margin: 0.25rem;
+}
+
+.bg-blue-600 {
+    background-color: #2563eb;
+}
+.text-white {
+    color: white;
+}
+.bg-gray-200 {
+    background-color: #e5e7eb;
+}
+.rounded {
+    border-radius: 0.25rem;
+}
+.mb-4 {
+    margin-bottom: 1rem;
+}
+.p-6 {
+    padding: 1.5rem;
+}
+.max-w-5xl {
+    max-width: 64rem;
+}
+.mx-auto {
+    margin-left: auto;
+    margin-right: auto;
+}
+.font-bold {
+    font-weight: bold;
+}
+.text-2xl {
+    font-size: 1.5rem;
+}
+.space-y-2 > * + * {
+    margin-top: 0.5rem;
+}
+.text-blue-600 {
+    color: #2563eb;
+}
+.underline {
+    text-decoration: underline;
+}
+.border {
+    border: 1px solid #d1d5db;
+}
+.px-2 {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+}
+.py-1 {
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+}
+.px-3 {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+}
+.py-2 {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+}
+.px-4 {
+    padding-left: 1rem;
+    padding-right: 1rem;
+}
+.text-sm {
+    font-size: 0.875rem;
+}
+.mr-2 {
+    margin-right: 0.5rem;
+}
+.mt-4 {
+    margin-top: 1rem;
+}
+.mt-2 {
+    margin-top: 0.5rem;
+}
+.inline-block {
+    display: inline-block;
+}
+.whitespace-pre-line {
+    white-space: pre-line;
+}
+.mb-2 {
+    margin-bottom: 0.5rem;
+}
+.space-y-2 > * + * {
+    margin-top: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- move category constants to new constants.ts
- add toggle-able preview in `EmailCard` for Gmail-style snippets
- allow selecting "All accounts" in `AccountSelector`
- fetch emails across accounts in `App` when selected
- add CSS utilities for text color and underline

## Testing
- `npm run lint` within `frontend`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d6d122d108327ad54a1144734b755